### PR TITLE
Test optimize ring serialisation

### DIFF
--- a/src/ringSignature.ts
+++ b/src/ringSignature.ts
@@ -507,7 +507,7 @@ export class RingSignature {
    */
   private static computeC(
     ring: Point[],
-    serializeRing: bigint[],
+    serializedRing: bigint[],
     messageDigest: bigint,
     params: {
       index: number;
@@ -540,7 +540,7 @@ export class RingSignature {
       const alphaG = G.mult(params.alpha);
       // if !config.evmCompatibility, the ring is not added to the hash
       // if config.evmCompatibility, the message is only added in the first iteration
-      const hashContent = (config?.evmCompatibility ? [] : serializeRing)
+      const hashContent = (config?.evmCompatibility ? [] : serializedRing)
         .concat(
           (config?.evmCompatibility && params.index === 1) ||
             !config?.evmCompatibility
@@ -564,7 +564,7 @@ export class RingSignature {
         ring[params.previousIndex].mult(params.previousC),
       );
 
-      const hashContent = (config?.evmCompatibility ? [] : serializeRing)
+      const hashContent = (config?.evmCompatibility ? [] : serializedRing)
         .concat(
           (config?.evmCompatibility && params.index === 1) ||
             !config?.evmCompatibility


### PR DESCRIPTION
Pass the serialized ring as an argument of the computeC function. 
Avoiding to compute it n times while signing and verifying. 
Could be improved by taking in count the config (not computing it at all when evm is true instead of 1 rigth now). 